### PR TITLE
Add support for our temporary target

### DIFF
--- a/crates/compiler/src/compile.rs
+++ b/crates/compiler/src/compile.rs
@@ -49,3 +49,6 @@
 //! translation—the benefits of not having to manually perform this additional
 //! work far outweighs that downside. If we _do_ need any additional control, we
 //! can always modify this process at a later date.
+
+#[cfg(test)]
+mod test {}

--- a/crates/rust-test-input/src/lib.rs
+++ b/crates/rust-test-input/src/lib.rs
@@ -1,14 +1,6 @@
+#![no_std]
+
+/// Adds two numbers together.
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
 }

--- a/docs/Getting LLVM IR Output.md
+++ b/docs/Getting LLVM IR Output.md
@@ -8,9 +8,9 @@ this project.
 ## Rust
 
 `rustc` will emit LLVM IR when passed the `--emit=llvm-ir` flag, and LLVM bytecode when passed the
-`--emit=llvm-bc`. This will output `.ll` files into the `target` directory corresponding to your
-compiled file. For more information, see the
-[`rustc` developer guide](https://rustc-dev-guide.rust-lang.org/backend/debugging.html).
+`--emit=llvm-bc`. This will output `.ll` (or `.bc`) files into the `target` directory corresponding
+to your compiled file (usually in `build-type/deps/crate-name-hash.ll`). For more information, see
+the [`rustc` developer guide](https://rustc-dev-guide.rust-lang.org/backend/debugging.html).
 
 - This can be passed to the correct compiler when using cargo by calling
   `cargo rustc -- --emit=llvm-ir`.


### PR DESCRIPTION
# Summary

For the current phase of work we are requiring that input LLVM IR be built to target the `aarch64-unknown-none-softfloat` target. This means that it can make no assumptions about either the host operating system (as there is none), nor the target ABI (meaning that we fall back to platform codegen ABI convention, and hence that `rustc` will not do anything funky here).

# Details

We add support in the nix derivation (`flake.nix`) so that this target is automatically made available in the sandbox. It may be necessary to add it at the system level as well, depending on how your development environment is set up.

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
