### PR TITLE
Make the nix stuff work reliably

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-cargo clippy --all-targets --all-features -- -D warnings && cargo +nightly fmt && npx lint-staged
+npx lint-staged

--- a/flake.nix
+++ b/flake.nix
@@ -71,9 +71,9 @@
 
         # We get your default shell to make sure things feel familiar in the dev shell.
         getUserShellCommand = if pkgs.stdenv.hostPlatform.isDarwin then
-          "dscl . -read ~ UserShell | cut -d ' ' -f2"
+          "dscl . -read ~ UserShell | cut -d ' ' -f2 | tr -d '\n'"
         else
-          "getent passwd $USER | cut -d ':' -f7";
+          "getent passwd $USER | cut -d ':' -f7 | tr -d '\n'";
       in {
         packages = {
           inherit all;
@@ -98,6 +98,10 @@
         devShells.ci = craneLib.devShell {
           LLVM_SYS_180_PREFIX = "${pkgs.lib.getDev pkgs.llvmPackages_18.libllvm}";
           inputsFrom = lib.attrValues llvmToCairo;
+
+          packages = [
+            pkgs.nodejs_22
+          ];
         };
       }
     );

--- a/package.json
+++ b/package.json
@@ -8,11 +8,15 @@
   "lint-staged": {
     "(*.md|*.toml|*.json|*.yaml|*.yml|*.css|*.js|*.ts)": [
       "prettier --write"
+    ],
+    "*.rs": [
+      "rustfmt --unstable-features --edition 2021",
+      "clippy-driver"
     ]
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npx lint-staged && cargo clippy -- -D warnings"
+      "pre-commit": "npx lint-staged"
     }
   },
   "scripts": {


### PR DESCRIPTION
# Summary

This fixes some commands that were depending on things being in the system path and not provided by the nix development environment. It also makes the precommit hooks more efficient, now only ever running on changed files as needed.

# Details

As long as CI passes this should be good.

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
