### PR TITLE
Fix the clippy check precommit hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Rust
 /target
+main
 
 # Tooling
 .idea/

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,0 +1,12 @@
+export default {
+  // These are simple, as they can just run prettier directly on any number of files.
+  "(*.md|*.toml|*.json|*.yaml|*.yml|*.css|*.js|*.mjs|*.ts)": ["prettier --write"],
+
+  // Unfortunately `clippy-driver` can only accept one file at a time, so we have to create an
+  // individual clippy task for each changed file.
+  "*.rs": async (stagedFiles) =>
+    [
+      `rustfmt --unstable-features --edition 2021 ${stagedFiles.join(" ")}`,
+      stagedFiles.map((filename) => `clippy-driver ${filename}`),
+    ].flat(),
+};

--- a/package.json
+++ b/package.json
@@ -5,15 +5,6 @@
     "prettier": "3.3.3",
     "prettier-plugin-toml": "2.0.1"
   },
-  "lint-staged": {
-    "(*.md|*.toml|*.json|*.yaml|*.yml|*.css|*.js|*.ts)": [
-      "prettier --write"
-    ],
-    "*.rs": [
-      "rustfmt --unstable-features --edition 2021",
-      "clippy-driver"
-    ]
-  },
   "husky": {
     "hooks": {
       "pre-commit": "npx lint-staged"


### PR DESCRIPTION
# Summary

It turns out that `clippy-driver` can only accept single files as input, while `lint-staged` calls by default with batches of files. This uses the JS configuration option to instead create a separate task for each Rust file that needs to be linted.

# Details

N/A

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
